### PR TITLE
Fix container image registry path

### DIFF
--- a/appliance/uci_image.ks
+++ b/appliance/uci_image.ks
@@ -91,7 +91,7 @@ EOF
 echo "" >> /etc/ssh/sshd_config
 
 # Pull the latest UCI Image
-podman pull docker://hub.docker.com/manageiq/v2v-conversion-host:latest
+podman pull docker.io/manageiq/v2v-conversion-host:latest
 
 chvt 1
 


### PR DESCRIPTION
Fix error pulling the conversion host container image

```
Trying to pull docker://hub.docker.com/manageiq/v2v-conversion-host:latest...ERRO[0000] Error 
pulling image ref //hub.docker.com/manageiq/v2v-conversion-host:latest: Error initializing source 
docker://hub.docker.com/manageiq/v2v-conversion-host:latest: pinging docker registry returned: 
error pinging registry hub.docker.com, response code 404 (Not Found)
```