### PR TITLE
Extract iso

### DIFF
--- a/container/entrypoint
+++ b/container/entrypoint
@@ -47,4 +47,5 @@ echo "Listing content of /data"
 ls -lR /data || true
 
 echo "Starting virt-v2v-wrapper..."
+export VIRTIO_WIN=/usr/share/virtio-win
 exec /usr/bin/virt-v2v-wrapper $@ < /var/lib/uci/input.json

--- a/container/grab_qemu_ga.sh
+++ b/container/grab_qemu_ga.sh
@@ -16,3 +16,28 @@ for version in "${!location[@]}"
         file=$(curl "${location[$version]}" 2>/dev/null| grep -Po '(?<=href=")qemu-guest-agent[^"]*.rpm' | head -1)
         curl ${location[$version]}$file -o $save_dir/$version/$file
     done
+
+#
+# Unpack everything from the virtio-win ISO so that we can remove it.
+#
+
+cd /usr/share/virtio-win
+pwd
+# Remove the driver directory to avoid duplicates
+rm -frv drivers
+# Extract the ISO
+ISO="/usr/share/virtio-win/virtio-win.iso"
+echo "Extracting $ISO"
+# First create directories
+for f in `isoinfo -i "$ISO" -f -J` ; do
+    mkdir -p ./`dirname "$f"`
+done
+# Then extract files
+for f in ` isoinfo -i "$ISO" -f -J`; do
+    if [ ! -d "./$f" ] ; then
+      isoinfo -i "$ISO" -J -x "$f" > "./$f"
+    fi
+done
+# Remove the ISO(s)
+rm -fv *.iso
+ls -lR

--- a/container/grab_qemu_ga.sh
+++ b/container/grab_qemu_ga.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
-# Define the locations to search inside for "qemu-guest-agent"
+set -e
 
+# Define the locations to search inside for "qemu-guest-agent"
 declare -A location=(
     ['el6']='http://vault.centos.org/6.9/os/x86_64/Packages/'
     ['el7']='http://vault.centos.org/7.6.1810/os/x86_64/Packages/'


### PR DESCRIPTION
virt-v2v can use either the /usr/share/virtio-win directory or the ISO as
source for drivers/tools, not both. By default the ISO is picked if it exists
in the file system. This makes it tricky for us because we store Linux qemu-ga
RPMs only in the directory and the directory does not contain all the drivers
(only limited subset). Without any fall-back mechanism in virt-v2v the best
solution is to extract the ISO content and remove it.
