### PR TITLE
Enhance libguestfs appliance use

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -53,10 +53,10 @@ RUN /usr/bin/supermin \
         --host-cpu x86_64 \
         /usr/lib64/guestfs/supermin.d \
         -o /usr/lib64/guestfs.fixed/ && \
-    rm -frv /usr/lib64/guestfs/* && \
-    mv -v /usr/lib64/guestfs.fixed/* /usr/lib64/guestfs && \
-    touch /usr/lib64/guestfs/README.fixed && \
-    LIBGUESTFS_BACKEND=direct libguestfs-test-tool
+    touch /usr/lib64/guestfs.fixed/README.fixed && \
+    LIBGUESTFS_PATH=/usr/lib64/guestfs.fixed \
+    LIBGUESTFS_BACKEND=direct \
+    libguestfs-test-tool
 
 RUN install --mode=0775 --group=0 -d /data && \
     install --mode=0775 --group=0 -d /data/input && \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -49,7 +49,7 @@ RUN /usr/bin/supermin \
         --verbose \
         --copy-kernel \
         --format ext2 \
-        --size 300M \
+        --size 1G \
         --host-cpu x86_64 \
         /usr/lib64/guestfs/supermin.d \
         -o /usr/lib64/guestfs.fixed/ && \

--- a/container/entrypoint
+++ b/container/entrypoint
@@ -9,6 +9,8 @@ if ! whoami &>/dev/null; then
 fi
 #####
 
+# Run a set of tests and lookups. Basically things that would help us debug
+# miss-configurations and failures during startup.
 set -x +e
 VDDK="/opt/vmware-vix-disklib-distrib/"
 ls -l "/usr/lib64/nbdkit/plugins/nbdkit-vddk-plugin.so"

--- a/container/entrypoint
+++ b/container/entrypoint
@@ -19,7 +19,9 @@ ls -ld "$VDDK"
 # location, the path is hard-coded in wrapper.
 lib="$(find "$VDDK" -name libvixDiskLib.so.6)"
 LD_LIBRARY_PATH="$(dirname "$lib")" nbdkit --dump-plugin vddk
-LIBGUESTFS_BACKEND='direct' libguestfs-test-tool
+export LIBGUESTFS_BACKEND='direct'
+export LIBGUESTFS_PATH=/usr/lib64/guestfs.fixed
+libguestfs-test-tool
 set +x -e
 
 echo


### PR DESCRIPTION
The patch removes the hack for the overlay filesystem and keeps the fixed appliance in a special directory. LIBGUESTFS_PATH variable is used to tell libguestfs the location of the fixed appliance explicitly. This seems to be the preferred use of the fixed appliance.

Size of the appliance is also increased to 1 GB. The stability of the appliance cannot be guaranteed if there is not enough free space for temporary files. Unfortunately it is not clear what is the minimum safe space.