### PR TITLE
Fix el8 yum repo path for qemu-guest-agent

### DIFF
--- a/container/grab_qemu_ga.sh
+++ b/container/grab_qemu_ga.sh
@@ -5,7 +5,7 @@ set -e
 declare -A location=(
     ['el6']='http://vault.centos.org/6.9/os/x86_64/Packages/'
     ['el7']='http://vault.centos.org/7.6.1810/os/x86_64/Packages/'
-    ['el8']='http://mirror.centos.org/centos-8/8.0.1905/AppStream/x86_64/os/Packages/'
+    ['el8']='http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/Packages/'
     ['fc28']='http://ftp.fi.muni.cz/pub/linux/fedora/linux/releases/30/Everything/x86_64/os/Packages/q/'
     ['lp151']='http://download.opensuse.org/distribution/leap/15.1/repo/oss/x86_64/'
     )


### PR DESCRIPTION
The current path no longer exists as CentOS 8 released a new version. Rather than setting to a specific release, changing to use the latest.

Build failure:

```
Cannot find package 'qemu-guest-agent' in repo 'http://mirror.centos.org/centos-8/8.0.1905/AppStream/x86_64/os/Packages/'
The command '/bin/sh -c /tmp/grab_qemu_ga.sh && rm -fv /tmp/grab_qemu_ga.sh' returned a non-zero code: 1
```

Also noticed some other releases are not using the latest location as well as "fc28" pointing to fc30 packages.  But those don't cause build failure, so I left it... They should probably be reviewed though.