### PR TITLE
entrypoint: pass device numbers as hex

### DIFF
--- a/container/entrypoint
+++ b/container/entrypoint
@@ -33,7 +33,7 @@ if ls /dev/v2v-disk* 2>/dev/null ; then
       mkdir -p "/data/vm/disk$n"
       major=$(stat -c '%t' "$d")
       minor=$(stat -c '%T' "$d")
-      mknod "/data/vm/disk$n/disk.img" b $major $minor
+      mknod "/data/vm/disk$n/disk.img" b 0x$major 0x$minor
     fi
   done
 fi


### PR DESCRIPTION
stat reports major/minor device numbers as hex. We need to pass the
values to mknod as such ortherwise we'll end up with error or worse with
wrong block device.

This fixes commit 26fd34a from PR #21.

Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>